### PR TITLE
Add missing DB migration with ActiveStorage updates

### DIFF
--- a/db/migrate/20210610193027_update_active_storage.rb
+++ b/db/migrate/20210610193027_update_active_storage.rb
@@ -1,0 +1,27 @@
+# This migration comes from active_storage (originally 20190112182829)
+class UpdateActiveStorage < ActiveRecord::Migration[6.0]
+  def up
+    unless column_exists?(:active_storage_blobs, :service_name)
+      add_column :active_storage_blobs, :service_name, :string
+
+      if configured_service = ActiveStorage::Blob.service.name
+        ActiveStorage::Blob.unscoped.update_all(service_name: configured_service)
+      end
+
+      change_column :active_storage_blobs, :service_name, :string, null: false
+    end
+
+    create_table :active_storage_variant_records do |t|
+      t.belongs_to :blob, null: false, index: false
+      t.string :variation_digest, null: false
+
+      t.index %i[blob_id variation_digest], name: 'index_active_storage_variant_records_uniqueness', unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+  end
+
+  def down
+    remove_column :active_storage_blobs, :service_name
+    drop_table :active_storage_variant_records, if_exists: true, force: true
+  end
+end


### PR DESCRIPTION
It seems ActiveStorage was updated and the changes to `db/schema.rb` committed but not the couple of migrations generated by `bundle exec rails active_storage:update`. The column [service_name is referenced in db/schema.rb](https://github.com/deployment-from-scratch/rails-6.0-docs/blob/2d9ca72c6bfc8eecc173355278f6bb2770dbf6de/db/schema.rb#L36) but not in the [actual migration](https://github.com/deployment-from-scratch/rails-6.0-docs/blob/master/db/migrate/20181103163143_create_active_storage_tables.active_storage.rb).

This migration combines both of the generated by the rails generator and hard-codes the version timestamp [referenced already in the code](https://github.com/deployment-from-scratch/rails-6.0-docs/blob/2d9ca72c6bfc8eecc173355278f6bb2770dbf6de/db/schema.rb#L13)


